### PR TITLE
fix: images for kube2kube sample are hosted on quay

### DIFF
--- a/samples/kubernetes-to-kubernetes/api-deployment.yaml
+++ b/samples/kubernetes-to-kubernetes/api-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         - env:
             - name: REDIS_URL
               value: redis://redis:6379
-          image: fibonacci-api:latest
+          image: quay.io/konveyor/fibonacci-api:latest
           imagePullPolicy: Always
           name: api
           ports:

--- a/samples/kubernetes-to-kubernetes/web-deployment.yaml
+++ b/samples/kubernetes-to-kubernetes/web-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         - env:
             - name: API_URL
               value: http://api:1234/fib
-          image: fibonacci-web:latest
+          image: quay.io/konveyor/fibonacci-web:latest
           imagePullPolicy: Always
           name: web
           ports:


### PR DESCRIPTION
Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>