### PR TITLE
fix: Resolve bug of two service names getting detected in CloudFoundry sample

### DIFF
--- a/samples/cloud-foundry/manifest.yml
+++ b/samples/cloud-foundry/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
     -
-        name: move2kube-demo-cf
+        name: cfnodejsapp
         random-route: true
         memory: 256M
 ...

--- a/samples/cloud-foundry/package.json
+++ b/samples/cloud-foundry/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "main",
+  "name": "cfnodejsapp",
   "version": "0.1.0",
   "description": "This is a test web server",
   "keywords": [


### PR DESCRIPTION
Fixes- https://github.com/konveyor/move2kube-demos/issues/48

```
? Select all services that are needed:
Hints:
[The services unselected here will be ignored.]
  [Use arrows to move, space to select, <right> to all, <left> to none, type to filter]
> [✓]  move2kube-demo-cf
```

Signed-off-by: Akash Nayak <akash19nayak@gmail.com>