### PR TITLE
fix: Fix invalid HTTP URL bug in the application.properties of the Gateway service

### DIFF
--- a/samples/enterprise-app/src/gateway/src/main/resources/application-dev.properties
+++ b/samples/enterprise-app/src/gateway/src/main/resources/application-dev.properties
@@ -1,6 +1,6 @@
-services.orders.url=${ENTERPRISE_APP_ORDERS_URL:-http://orders:8080/orders}
-services.customers.url=${ENTERPRISE_APP_CUSTOMERS_URL:-http://customers:8080/customers}
-services.inventory.url=${ENTERPRISE_APP_INVENTORY_URL:-http://inventory:8080/products}
+services.orders.url=${ENTERPRISE_APP_ORDERS_URL:http://orders:8080/orders}
+services.customers.url=${ENTERPRISE_APP_CUSTOMERS_URL:http://customers:8080/customers}
+services.inventory.url=${ENTERPRISE_APP_INVENTORY_URL:http://inventory:8080/products}
 
 hystrix.command.ProductsCall.execution.isolation.thread.timeoutInMilliseconds=2000
 


### PR DESCRIPTION
The default URLs for the backend services (Orders, Customers, and Inventory) were containing a `-` prefix due to which the Gateway service was not able to communicate with the backend services. 

`Gateway` Pod logs
```console
[derRepository-1] i.k.d.g.repository.OrderRepository : Failed to obtain Orders, [-http://orders:8080/orders] is not a valid HTTP URL
[merRepository-1] i.k.d.g.repository.CustomerRepository : Failed to obtain Customers, [-http://customers:8080/customers] is not a valid HTTP URL
```

Signed-off-by: Akash Nayak <akash19nayak@gmail.com>