### PR TITLE
fix: Resolve database deployment permission issues

### DIFF
--- a/samples/enterprise-app/database/database-deployment.yaml
+++ b/samples/enterprise-app/database/database-deployment.yaml
@@ -32,6 +32,8 @@ spec:
                 secretKeyRef:
                   name: database-secret
                   key: password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
           volumeMounts:
             - name: secret-volume
               readOnly: true


### PR DESCRIPTION
The database pod was failing to start due to which the `prod` profile based deployment of enterprise-app was not working properly.

<img width="1307" alt="Screenshot 2022-06-27 at 8 01 09 PM" src="https://user-images.githubusercontent.com/14867323/175965819-c5e35a26-a29d-4b51-95f1-a1fabd08de26.png">

<img width="1792" alt="Screenshot 2022-06-27 at 8 08 00 PM" src="https://user-images.githubusercontent.com/14867323/175967289-0ea61932-9b04-40ee-8d82-c52d7daee1b4.png">

After fixing the database-deployment.yaml
<img width="1465" alt="Screenshot 2022-06-27 at 8 02 36 PM" src="https://user-images.githubusercontent.com/14867323/175966558-38add67f-01ed-4c52-8401-1188736eb13c.png">

<img width="1791" alt="Screenshot 2022-06-27 at 8 07 29 PM" src="https://user-images.githubusercontent.com/14867323/175967339-e7d30822-c83b-47e3-b83e-db0c29a5caf0.png">


Signed-off-by: Akash Nayak <akash19nayak@gmail.com>