### PR TITLE
fix: Use postgres v14.3 to resolve enterprise-app database issue with latest postgres image

### DIFF
--- a/samples/enterprise-app/database/database-deployment.yaml
+++ b/samples/enterprise-app/database/database-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       name: database
     spec:
       containers:
-        - image: postgres
+        - image: postgres:14.5
           imagePullPolicy: Always
           name: database
           ports:


### PR DESCRIPTION
The latest version of postgres image v15 is incompatible with the enterprise app database due to which the backend services (orders, customers and inventory) fail to run correctly and the frontend shows blank webpages. So, I am fixing the postgres image version to the previous working version.

[https://www.postgresql.org/docs/15/release-15.html](https://www.postgresql.org/docs/15/release-15.html#id-1.11.6.5.4)
```
Postgres Version 15 contains a number of changes that may affect compatibility with previous releases.
```

Signed-off-by: Akash Nayak <akash19nayak@gmail.com>